### PR TITLE
fix: fixes fading card tile titles by removing the BackdropFilter from OverlayContainer

### DIFF
--- a/lib/sources/app/styling/opacity/opacity_constants.dart
+++ b/lib/sources/app/styling/opacity/opacity_constants.dart
@@ -1,4 +1,4 @@
-const overlay = 0.8;
+const overlay = 0.84;
 const shadow = 0.20;
 const fadedColor = 0.33;
 const hover = 0.08;

--- a/lib/sources/presentation/widgets/cards/palette_card.dart
+++ b/lib/sources/presentation/widgets/cards/palette_card.dart
@@ -20,10 +20,13 @@ class PaletteCard extends StatelessWidget {
         title: title,
         subtitle: subtitle,
         backgroundColor: Theme.of(context).primaryColor,
-        child: Row(
-          children: colors
-              .map((color) => Expanded(child: Container(color: color)))
-              .toList(),
+        child: RepaintBoundary(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: colors
+                .map((color) => Expanded(child: Container(color: color)))
+                .toList(),
+          ),
         ),
       );
 }

--- a/lib/sources/presentation/widgets/containers/overlay_container.dart
+++ b/lib/sources/presentation/widgets/containers/overlay_container.dart
@@ -1,6 +1,3 @@
-import 'dart:ui';
-
-import 'package:colored/sources/app/styling/blur/blur_data.dart';
 import 'package:colored/sources/app/styling/elevation/elevation_data.dart';
 import 'package:colored/sources/app/styling/opacity/opacity_data.dart';
 import 'package:colored/sources/app/styling/radii/radius_data.dart';
@@ -26,7 +23,6 @@ class OverlayContainer extends StatelessWidget {
     final elevationScheme = ElevationData.of(context).elevationScheme;
     final radii = RadiusData.of(context).radiiScheme;
     final opacity = OpacityData.of(context).opacityScheme;
-    final blur = BlurData.of(context).blurScheme.medium;
     final borderRadius = this.borderRadius ?? BorderRadius.all(radii.large);
     return Material(
       elevation: elevation ?? elevationScheme.low,
@@ -34,12 +30,9 @@ class OverlayContainer extends StatelessWidget {
       borderRadius: borderRadius,
       child: ClipRRect(
         borderRadius: borderRadius,
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: blur.x, sigmaY: blur.y),
-          child: Container(
-            color: colors.primary.withOpacity(opacity.overlay),
-            child: child,
-          ),
+        child: Container(
+          color: colors.primary.withOpacity(opacity.overlay),
+          child: child,
         ),
       ),
     );


### PR DESCRIPTION
This closes #71 