### PR TITLE
feat(autocomplete): adds search autocomplete to colors and palettes (#143)

### DIFF
--- a/lib/sources/app/main_injector.dart
+++ b/lib/sources/app/main_injector.dart
@@ -3,6 +3,7 @@ import 'package:colored/sources/app/styling/colors/color_constants.dart'
     as colors;
 import 'package:colored/sources/data/api/models/index/api_index.dart';
 import 'package:colored/sources/domain/view_models/colors/color_suggestions/color_suggestions_injector.dart';
+import 'package:colored/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_injector.dart';
 import 'package:colored/sources/domain/view_models/colors/names_list/names_list_injector.dart';
 import 'package:colored/sources/domain/view_models/converter/connectivity/connectivity_injector.dart';
 import 'package:colored/sources/domain/view_models/converter/converter/converter_injector.dart';
@@ -16,6 +17,7 @@ import 'package:colored/sources/domain/view_models/palettes/palette_suggestions/
 import 'package:colored/sources/domain/view_models/palettes/palettes_list/palettes_list_injector.dart';
 import 'package:colored/sources/domain/view_models/palettes/palettes_navigation/palettes_navigation_injector.dart';
 import 'package:colored/sources/presentation/notifiers/colors/color_suggestions_notifier.dart';
+import 'package:colored/sources/presentation/notifiers/colors/color_suggestions_search_notifier.dart';
 import 'package:colored/sources/presentation/notifiers/colors/names_list_notifier.dart';
 import 'package:colored/sources/presentation/notifiers/converter/connectivity_notifier.dart';
 import 'package:colored/sources/presentation/notifiers/converter/converter_notifier.dart';
@@ -74,9 +76,14 @@ class MainInjector extends StatelessWidget {
                                 flavor: FlavorConfig.instance,
                                 apiIndex: apiIndex,
                               ),
-                              child: MainTabsNotifier(
-                                injector: const MainTabsInjector(),
-                                child: child,
+                              child: ColorSuggestionsSearchNotifier(
+                                injector: ColorSuggestionsSearchInjector(
+                                  apiIndex: apiIndex,
+                                ),
+                                child: MainTabsNotifier(
+                                  injector: const MainTabsInjector(),
+                                  child: child,
+                                ),
                               ),
                             ),
                           ),

--- a/lib/sources/data/api/services/suggestions/color_suggestions_search_api_service.dart
+++ b/lib/sources/data/api/services/suggestions/color_suggestions_search_api_service.dart
@@ -1,0 +1,34 @@
+import 'package:colored/sources/data/api/models/index/api_index.dart';
+import 'package:colored/sources/data/api/models/responses/api_response.dart';
+import 'package:colored/sources/data/api/services/base/request/page_request_builder.dart';
+import 'package:colored/sources/data/api/services/base/response/response_parser.dart';
+import 'package:colored/sources/data/api/services/names/base_api_names_service.dart';
+import 'package:colored/sources/data/network_client/http_client.dart';
+import 'package:colored/sources/domain/data_models/named_color.dart';
+
+class ColorSuggestionsSearchApiService extends BaseApiNamesService<NamedColor> {
+  const ColorSuggestionsSearchApiService({
+    required HttpClient client,
+    required ApiIndex? apiIndex,
+    required PageRequestBuilder pageRequestBuilder,
+    required ResponseParser<ApiResponse> parser,
+  })  : _apiIndex = apiIndex,
+        super(
+          client: client,
+          pageRequestBuilder: pageRequestBuilder,
+          parser: parser,
+        );
+
+  final ApiIndex? _apiIndex;
+
+  @override
+  Uri? get baseUri => _apiIndex?.suggestions?.colors?.search?.names?.endpoint;
+
+  @override
+  NamedColor parseItemFromJson(Map<String, dynamic> json) {
+    final namedColorJson = Map<String, dynamic>.from(
+      json[NamedColor.suggestionMappingKey],
+    );
+    return NamedColor.fromJson(namedColorJson);
+  }
+}

--- a/lib/sources/data/api/services/suggestions/palette_suggestions_search_api_service.dart
+++ b/lib/sources/data/api/services/suggestions/palette_suggestions_search_api_service.dart
@@ -1,0 +1,34 @@
+import 'package:colored/sources/data/api/models/index/api_index.dart';
+import 'package:colored/sources/data/api/models/responses/api_response.dart';
+import 'package:colored/sources/data/api/services/base/request/page_request_builder.dart';
+import 'package:colored/sources/data/api/services/base/response/response_parser.dart';
+import 'package:colored/sources/data/api/services/names/base_api_names_service.dart';
+import 'package:colored/sources/data/network_client/http_client.dart';
+import 'package:colored/sources/domain/data_models/palette.dart';
+
+class PaletteSuggestionsSearchApiService extends BaseApiNamesService<Palette> {
+  const PaletteSuggestionsSearchApiService({
+    required HttpClient client,
+    required ApiIndex? apiIndex,
+    required PageRequestBuilder pageRequestBuilder,
+    required ResponseParser<ApiResponse> parser,
+  })  : _apiIndex = apiIndex,
+        super(
+          client: client,
+          pageRequestBuilder: pageRequestBuilder,
+          parser: parser,
+        );
+
+  final ApiIndex? _apiIndex;
+
+  @override
+  Uri? get baseUri => _apiIndex?.suggestions?.palettes?.names?.endpoint;
+
+  @override
+  Palette parseItemFromJson(Map<String, dynamic> json) {
+    final paletteJson = Map<String, dynamic>.from(
+      json[Palette.suggestionMappingKey],
+    );
+    return Palette.fromJson(paletteJson);
+  }
+}

--- a/lib/sources/data/api/services/suggestions/suggestions_search_api_service.dart
+++ b/lib/sources/data/api/services/suggestions/suggestions_search_api_service.dart
@@ -1,0 +1,38 @@
+import 'package:colored/sources/data/pagination/list_page.dart';
+import 'package:colored/sources/data/pagination/page_info.dart';
+import 'package:colored/sources/data/services/names/paginated_names_service.dart';
+
+class SuggestionsSearchApiService<T> implements PaginatedNamesService<T> {
+  SuggestionsSearchApiService({
+    required PaginatedNamesService<T> namesService,
+    int searchLengthTrigger = 2,
+  })  : assert(searchLengthTrigger > 1),
+        _searchLengthTrigger = searchLengthTrigger,
+        _namesService = namesService;
+
+  final PaginatedNamesService<T> _namesService;
+  final int _searchLengthTrigger;
+  String _lastSearchStart = "";
+  ListPage<T>? _lastListPage;
+
+  @override
+  Future<ListPage<T>?> fetchContainingSearch(
+    String searchString, {
+    required PageInfo pageInfo,
+  }) async {
+    if (searchString.length < _searchLengthTrigger) {
+      return _lastListPage;
+    }
+    final searchStart = searchString.substring(0, _searchLengthTrigger);
+    if (_lastSearchStart == searchStart) {
+      return _lastListPage;
+    }
+    _lastSearchStart = searchStart;
+    final listPage = await _namesService.fetchContainingSearch(
+      _lastSearchStart,
+      pageInfo: pageInfo,
+    );
+    _lastListPage = listPage;
+    return listPage;
+  }
+}

--- a/lib/sources/domain/data_models/nameable.dart
+++ b/lib/sources/domain/data_models/nameable.dart
@@ -1,0 +1,11 @@
+class Nameable {
+  const Nameable(this.name);
+
+  final String name;
+
+  @override
+  bool operator ==(Object other) => other is Nameable && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
+}

--- a/lib/sources/domain/data_models/named_color.dart
+++ b/lib/sources/domain/data_models/named_color.dart
@@ -1,10 +1,11 @@
+import 'package:colored/sources/domain/data_models/nameable.dart';
 import 'package:vector_math/hash.dart';
 
-class NamedColor {
+class NamedColor extends Nameable {
   const NamedColor({
-    required this.name,
+    required String name,
     required this.hex,
-  });
+  }) : super(name);
 
   factory NamedColor.fromMapEntry(MapEntry<String, dynamic> entry) =>
       NamedColor(name: entry.value, hex: "#${entry.key.toUpperCase()}");
@@ -19,7 +20,6 @@ class NamedColor {
   static String mocksMappingKey = "colors";
   static String suggestionMappingKey = "color";
 
-  final String name;
   final String hex;
 
   @override

--- a/lib/sources/domain/data_models/palette.dart
+++ b/lib/sources/domain/data_models/palette.dart
@@ -1,9 +1,13 @@
 import 'package:collection/collection.dart';
+import 'package:colored/sources/domain/data_models/nameable.dart';
 import 'package:colored/sources/domain/data_models/named_color.dart';
 import 'package:vector_math/hash.dart';
 
-class Palette {
-  const Palette({required this.name, required this.hexCodes});
+class Palette extends Nameable {
+  const Palette({
+    required String name,
+    required this.hexCodes,
+  }) : super(name);
 
   factory Palette.fromMapEntry(MapEntry<String, List<String>?> mapEntry) {
     final hexCodes = mapEntry.value!.map((c) => "#${c.toUpperCase()}").toList();
@@ -18,11 +22,13 @@ class Palette {
     return Palette(name: json[_Key.name.value], hexCodes: hexCodes);
   }
 
+  factory Palette.fromNamedColor(NamedColor namedColor) =>
+      Palette(name: namedColor.name, hexCodes: [namedColor.hex]);
+
   static String nameKey = _Key.name.value;
   static String hexCodesKey = _Key.hexCodes.value;
   static String suggestionMappingKey = "palette";
 
-  final String name;
   final List<String> hexCodes;
 
   @override

--- a/lib/sources/domain/view_models/base/names/base_names_data.dart
+++ b/lib/sources/domain/view_models/base/names/base_names_data.dart
@@ -1,0 +1,19 @@
+import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
+import 'package:flutter/material.dart';
+
+class BaseNamesData extends InheritedWidget {
+  const BaseNamesData({
+    required this.state,
+    required this.onSearchStarted,
+    required this.onSearchCleared,
+    required Widget child,
+    Key? key,
+  }) : super(key: key, child: child);
+
+  final NamesListState state;
+  final Future<void> Function(String) onSearchStarted;
+  final void Function() onSearchCleared;
+
+  @override
+  bool updateShouldNotify(BaseNamesData oldWidget) => oldWidget.state != state;
+}

--- a/lib/sources/domain/view_models/base/names/base_names_view_model.dart
+++ b/lib/sources/domain/view_models/base/names/base_names_view_model.dart
@@ -30,7 +30,7 @@ abstract class BaseNamesListViewModel<T> {
 
   NamesListState buildInitialState();
 
-  NamesListState buildSearchPendingState(String searchString);
+  NamesListState? buildSearchPendingState(String searchString);
 
   NamesListState buildSearchFailedState(String searchString);
 
@@ -131,6 +131,9 @@ abstract class BaseNamesListViewModel<T> {
 
   void _notifySearchPending(String searchString) {
     final pendingState = buildSearchPendingState(searchString);
+    if (pendingState == null) {
+      return;
+    }
     _stateController.sink.add(pendingState);
   }
 

--- a/lib/sources/domain/view_models/base/names/paginated_names_data.dart
+++ b/lib/sources/domain/view_models/base/names/paginated_names_data.dart
@@ -1,14 +1,12 @@
-import 'package:colored/sources/domain/data_models/named_color.dart';
+import 'package:colored/sources/domain/view_models/base/names/base_names_data.dart';
 import 'package:colored/sources/domain/view_models/base/names/base_names_view_model.dart';
 import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
-import 'package:colored/sources/domain/view_models/base/names/paginated_names_data.dart';
 import 'package:flutter/material.dart';
 
-class NamesListData extends PaginatedNamesData<NamedColor> {
-  const NamesListData({
-    required this.onBackPressed,
+class PaginatedNamesData<T> extends BaseNamesData {
+  const PaginatedNamesData({
     required NamesListState state,
-    required PaginatedNamesSearcher<NamedColor> onPageFinished,
+    required this.onPageFinished,
     required Future<void> Function(String) onSearchStarted,
     required void Function() onSearchCleared,
     required Widget child,
@@ -16,14 +14,10 @@ class NamesListData extends PaginatedNamesData<NamedColor> {
   }) : super(
           key: key,
           state: state,
-          onPageFinished: onPageFinished,
           onSearchStarted: onSearchStarted,
           onSearchCleared: onSearchCleared,
           child: child,
         );
 
-  final void Function() onBackPressed;
-
-  static NamesListData? of(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType(aspect: NamesListData);
+  final PaginatedNamesSearcher<T> onPageFinished;
 }

--- a/lib/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_data.dart
+++ b/lib/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_data.dart
@@ -1,0 +1,24 @@
+import 'package:colored/sources/domain/view_models/base/names/base_names_data.dart';
+import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
+import 'package:flutter/material.dart';
+
+class ColorSuggestionsSearchData extends BaseNamesData {
+  const ColorSuggestionsSearchData({
+    required NamesListState state,
+    required Future<void> Function(String) onSearchStarted,
+    required void Function() onSearchCleared,
+    required Widget child,
+    Key? key,
+  }) : super(
+          key: key,
+          state: state,
+          onSearchStarted: onSearchStarted,
+          onSearchCleared: onSearchCleared,
+          child: child,
+        );
+
+  static ColorSuggestionsSearchData? of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType(
+        aspect: ColorSuggestionsSearchData,
+      );
+}

--- a/lib/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_injector.dart
+++ b/lib/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_injector.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:colored/configuration/flavor_config.dart';
+import 'package:colored/sources/data/api/models/index/api_index.dart';
+import 'package:colored/sources/data/api/services/base/request/uri_page_request_builder.dart';
+import 'package:colored/sources/data/api/services/base/response/api_response_parser.dart';
+import 'package:colored/sources/data/api/services/suggestions/color_suggestions_search_api_service.dart';
+import 'package:colored/sources/data/api/services/suggestions/suggestions_search_api_service.dart';
+import 'package:colored/sources/data/network_client/safe_http_client.dart';
+import 'package:colored/sources/data/pagination/list_paginator.dart';
+import 'package:colored/sources/data/services/data_loader/color_suggestions_loader.dart';
+import 'package:colored/sources/data/services/map_filter/color_names_filter.dart';
+import 'package:colored/sources/data/services/names/color_names_service.dart';
+import 'package:colored/sources/data/services/names/paginated_color_names_service.dart';
+import 'package:colored/sources/data/services/string_bundle/root_string_bundle.dart';
+import 'package:colored/sources/domain/data_models/named_color.dart';
+import 'package:colored/sources/domain/view_models/base/names/base_names_injector.dart';
+import 'package:colored/sources/domain/view_models/base/names/base_names_view_model.dart';
+import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
+import 'package:colored/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_view_model.dart';
+import 'package:colored/sources/domain/view_models/colors/names_list/names_list_view_model.dart';
+
+class ColorSuggestionsSearchInjector extends BaseNamesInjector<NamedColor> {
+  const ColorSuggestionsSearchInjector({
+    ApiIndex? apiIndex,
+  }) : super(apiIndex: apiIndex);
+
+  @override
+  BaseNamesListViewModel<NamedColor> injectApiViewModel(
+    ApiIndex apiIndex, [
+    StreamController<NamesListState>? stateController,
+  ]) =>
+      NamesListViewModel(
+        stateController: stateController ?? StreamController<NamesListState>(),
+        namesService: SuggestionsSearchApiService<NamedColor>(
+          namesService: ColorSuggestionsSearchApiService(
+            client: const SafeHttpClient(),
+            pageRequestBuilder: const UriPageRequestBuilder(),
+            apiIndex: apiIndex,
+            parser: const ApiResponseParser(),
+          ),
+        ),
+      );
+
+  @override
+  BaseNamesListViewModel<NamedColor> injectLocalViewModel([
+    StreamController<NamesListState>? stateController,
+  ]) =>
+      ColorSuggestionsSearchViewModel(
+        stateController: stateController ?? StreamController<NamesListState>(),
+        namesService: PaginatedColorNamesService(
+          namesService: ColorNamesService(
+            dataLoader: ColorSuggestionsLoader(
+              stringBundle: const RootStringBundle(),
+              colorSuggestionsDataPath:
+                  FlavorConfig.instance.values.dataPath.colorSuggestionData,
+            ),
+            filter: const ColorNamesFilter(),
+          ),
+          paginator: const ListPaginator(),
+        ),
+      );
+}

--- a/lib/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_view_model.dart
+++ b/lib/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_view_model.dart
@@ -2,15 +2,16 @@ import 'dart:async';
 
 import 'package:colored/sources/data/pagination/page_info.dart';
 import 'package:colored/sources/data/services/names/paginated_names_service.dart';
-import 'package:colored/sources/domain/data_models/palette.dart';
+import 'package:colored/sources/domain/data_models/named_color.dart';
 import 'package:colored/sources/domain/view_models/base/names/base_names_view_model.dart';
 import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
-import 'package:colored/sources/domain/view_models/palettes/palettes_list/palettes_list_state.dart';
+import 'package:colored/sources/domain/view_models/colors/names_list/names_list_state.dart';
 
-class PalettesListViewModel extends BaseNamesListViewModel<Palette> {
-  const PalettesListViewModel({
+class ColorSuggestionsSearchViewModel
+    extends BaseNamesListViewModel<NamedColor> {
+  const ColorSuggestionsSearchViewModel({
     required StreamController<NamesListState> stateController,
-    required PaginatedNamesService<Palette> namesService,
+    required PaginatedNamesService<NamedColor> namesService,
   }) : super(
           stateController: stateController,
           namesService: namesService,
@@ -24,14 +25,13 @@ class PalettesListViewModel extends BaseNamesListViewModel<Palette> {
       NoneFound(search: searchString);
 
   @override
-  NamesListState? buildSearchPendingState(String searchString) =>
-      Pending(search: searchString);
+  NamesListState? buildSearchPendingState(String searchString) => null;
 
   @override
   NamesListState buildSearchSuccessState(
     String searchString, {
     required PageInfo pageInfo,
-    required List<Palette> items,
+    required List<NamedColor> items,
   }) =>
       Found(items, search: searchString, pageInfo: pageInfo);
 }

--- a/lib/sources/domain/view_models/colors/names_list/names_list_view_model.dart
+++ b/lib/sources/domain/view_models/colors/names_list/names_list_view_model.dart
@@ -24,7 +24,7 @@ class NamesListViewModel extends BaseNamesListViewModel<NamedColor> {
       NoneFound(search: searchString);
 
   @override
-  NamesListState buildSearchPendingState(String searchString) =>
+  NamesListState? buildSearchPendingState(String searchString) =>
       Pending(search: searchString);
 
   @override

--- a/lib/sources/domain/view_models/palettes/palette_suggestions/search/palette_suggestions_search_view_model.dart
+++ b/lib/sources/domain/view_models/palettes/palette_suggestions/search/palette_suggestions_search_view_model.dart
@@ -7,8 +7,9 @@ import 'package:colored/sources/domain/view_models/base/names/base_names_view_mo
 import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
 import 'package:colored/sources/domain/view_models/palettes/palettes_list/palettes_list_state.dart';
 
-class PalettesListViewModel extends BaseNamesListViewModel<Palette> {
-  const PalettesListViewModel({
+class PaletteSuggestionsSearchViewModel
+    extends BaseNamesListViewModel<Palette> {
+  const PaletteSuggestionsSearchViewModel({
     required StreamController<NamesListState> stateController,
     required PaginatedNamesService<Palette> namesService,
   }) : super(
@@ -24,8 +25,7 @@ class PalettesListViewModel extends BaseNamesListViewModel<Palette> {
       NoneFound(search: searchString);
 
   @override
-  NamesListState? buildSearchPendingState(String searchString) =>
-      Pending(search: searchString);
+  NamesListState? buildSearchPendingState(String searchString) => null;
 
   @override
   NamesListState buildSearchSuccessState(

--- a/lib/sources/domain/view_models/palettes/palettes_list/palettes_list_data.dart
+++ b/lib/sources/domain/view_models/palettes/palettes_list/palettes_list_data.dart
@@ -1,27 +1,26 @@
 import 'package:colored/sources/domain/data_models/palette.dart';
 import 'package:colored/sources/domain/view_models/base/names/base_names_view_model.dart';
 import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
+import 'package:colored/sources/domain/view_models/base/names/paginated_names_data.dart';
 import 'package:flutter/material.dart';
 
-class PalettesListData extends InheritedWidget {
+class PalettesListData extends PaginatedNamesData<Palette> {
   const PalettesListData({
-    required this.state,
-    required this.onSearchChanged,
-    required this.onSearchStarted,
-    required this.onSearchCleared,
+    required NamesListState state,
+    required PaginatedNamesSearcher<Palette> onPageFinished,
+    required Future<void> Function(String) onSearchStarted,
+    required void Function() onSearchCleared,
     required Widget child,
     Key? key,
-  }) : super(key: key, child: child);
-
-  final NamesListState state;
-  final PaginatedNamesSearcher<Palette> onSearchChanged;
-  final Future<void> Function(String) onSearchStarted;
-  final void Function() onSearchCleared;
+  }) : super(
+          key: key,
+          state: state,
+          onPageFinished: onPageFinished,
+          onSearchStarted: onSearchStarted,
+          onSearchCleared: onSearchCleared,
+          child: child,
+        );
 
   static PalettesListData? of(BuildContext context) =>
       context.dependOnInheritedWidgetOfExactType(aspect: PalettesListData);
-
-  @override
-  bool updateShouldNotify(PalettesListData oldWidget) =>
-      state != oldWidget.state;
 }

--- a/lib/sources/presentation/layouts/colors/color_search/color_search_field.dart
+++ b/lib/sources/presentation/layouts/colors/color_search/color_search_field.dart
@@ -1,6 +1,9 @@
 import 'package:colored/resources/localization/localization.dart';
+import 'package:colored/sources/domain/data_models/palette.dart';
+import 'package:colored/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_data.dart';
 import 'package:colored/sources/domain/view_models/colors/names_list/names_list_data.dart';
-import 'package:colored/sources/presentation/widgets/text_fields/auto_focusing_search_field.dart';
+import 'package:colored/sources/domain/view_models/colors/names_list/names_list_state.dart';
+import 'package:colored/sources/presentation/widgets/text_fields/autocomplete_search_field.dart';
 import 'package:flutter/material.dart';
 
 class ColorSearchField extends StatelessWidget {
@@ -9,12 +12,26 @@ class ColorSearchField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final data = NamesListData.of(context)!;
+    final suggestionsData = ColorSuggestionsSearchData.of(context)!;
     final localization = Localization.of(context)!.namesList;
-    return AutoFocusingSearchField(
+    return AutocompleteSearchField(
+      autocompleteOptions: _buildSuggestionsOptions(suggestionsData),
       hintText: localization.search,
       onClearPressed: data.onSearchCleared,
       onSubmitted: data.onSearchStarted,
+      onChanged: suggestionsData.onSearchStarted,
       searchText: data.state.search,
     );
+  }
+
+  Iterable<Palette> _buildSuggestionsOptions(ColorSuggestionsSearchData data) {
+    final suggestionsState = data.state;
+    switch (suggestionsState.runtimeType) {
+      case Found:
+        final foundState = suggestionsState as Found;
+        return foundState.namedColors.map((c) => Palette.fromNamedColor(c));
+      default:
+        return [];
+    }
   }
 }

--- a/lib/sources/presentation/layouts/colors/names_list/names_list_layout.dart
+++ b/lib/sources/presentation/layouts/colors/names_list/names_list_layout.dart
@@ -39,7 +39,7 @@ class NamesListLayout extends StatelessWidget {
       return;
     }
     final foundState = data.state as Found;
-    data.onSearchChanged(
+    data.onPageFinished(
       foundState.search,
       currentItems: foundState.namedColors,
       currentPageInfo: foundState.pageInfo,

--- a/lib/sources/presentation/layouts/palettes/palette_search/palette_search_field.dart
+++ b/lib/sources/presentation/layouts/palettes/palette_search/palette_search_field.dart
@@ -12,7 +12,7 @@ class PaletteSearchField extends StatelessWidget {
     final localization = Localization.of(context)!.palettes;
     return AutoFocusingSearchField(
       hintText: localization.search,
-      onClearPressed: () => data.onSearchCleared,
+      onClearPressed: data.onSearchCleared,
       onSubmitted: data.onSearchStarted,
       searchText: data.state.search,
     );

--- a/lib/sources/presentation/layouts/palettes/palettes_list/palettes_list_layout.dart
+++ b/lib/sources/presentation/layouts/palettes/palettes_list/palettes_list_layout.dart
@@ -39,7 +39,7 @@ class PalettesListLayout extends StatelessWidget {
       return;
     }
     final foundState = data.state as Found;
-    data.onSearchChanged(
+    data.onPageFinished(
       foundState.search,
       currentItems: foundState.palettes,
       currentPageInfo: foundState.pageInfo,

--- a/lib/sources/presentation/notifiers/colors/color_suggestions_search_notifier.dart
+++ b/lib/sources/presentation/notifiers/colors/color_suggestions_search_notifier.dart
@@ -1,26 +1,28 @@
-import 'package:colored/sources/domain/data_models/palette.dart';
+import 'package:colored/sources/domain/data_models/named_color.dart';
 import 'package:colored/sources/domain/view_models/base/names/base_names_injector.dart';
 import 'package:colored/sources/domain/view_models/base/names/base_names_view_model.dart';
 import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
-import 'package:colored/sources/domain/view_models/palettes/palettes_list/palettes_list_data.dart';
+import 'package:colored/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_data.dart';
 import 'package:flutter/material.dart';
 
-class PalettesListNotifier extends StatefulWidget {
-  const PalettesListNotifier({
-    required this.injector,
+class ColorSuggestionsSearchNotifier extends StatefulWidget {
+  const ColorSuggestionsSearchNotifier({
     required this.child,
+    required this.injector,
     Key? key,
   }) : super(key: key);
 
-  final BaseNamesInjector<Palette> injector;
   final Widget child;
+  final BaseNamesInjector<NamedColor> injector;
 
   @override
-  _PalettesListNotifierState createState() => _PalettesListNotifierState();
+  _ColorSuggestionsSearchNotifierState createState() =>
+      _ColorSuggestionsSearchNotifierState();
 }
 
-class _PalettesListNotifierState extends State<PalettesListNotifier> {
-  late final BaseNamesListViewModel<Palette> _viewModel;
+class _ColorSuggestionsSearchNotifierState
+    extends State<ColorSuggestionsSearchNotifier> {
+  late final BaseNamesListViewModel<NamedColor> _viewModel;
 
   @override
   void initState() {
@@ -32,9 +34,8 @@ class _PalettesListNotifierState extends State<PalettesListNotifier> {
   Widget build(BuildContext context) => StreamBuilder<NamesListState>(
         initialData: _viewModel.initialState,
         stream: _viewModel.stateStream,
-        builder: (context, snapshot) => PalettesListData(
+        builder: (context, snapshot) => ColorSuggestionsSearchData(
           state: snapshot.data ?? _viewModel.initialState,
-          onPageFinished: _viewModel.searchNextPage,
           onSearchStarted: _viewModel.startSearch,
           onSearchCleared: _viewModel.clearSearch,
           child: widget.child,

--- a/lib/sources/presentation/notifiers/colors/names_list_notifier.dart
+++ b/lib/sources/presentation/notifiers/colors/names_list_notifier.dart
@@ -34,7 +34,7 @@ class _NamesListNotifierState extends State<NamesListNotifier> {
         stream: _viewModel.stateStream,
         builder: (_, snapshot) => NamesListData(
           state: snapshot.data ?? _viewModel.initialState,
-          onSearchChanged: _viewModel.searchNextPage,
+          onPageFinished: _viewModel.searchNextPage,
           onSearchStarted: _viewModel.startSearch,
           onSearchCleared: _viewModel.clearSearch,
           onBackPressed: _viewModel.clearSearch,

--- a/lib/sources/presentation/widgets/chips/color_chip.dart
+++ b/lib/sources/presentation/widgets/chips/color_chip.dart
@@ -1,6 +1,5 @@
-import 'package:colored/sources/app/styling/radii/radius_data.dart';
-import 'package:colored/sources/common/extensions/hex_color.dart';
 import 'package:colored/sources/presentation/widgets/chips/suggestion_chip.dart';
+import 'package:colored/sources/presentation/widgets/containers/gradient_circle.dart';
 import 'package:flutter/material.dart';
 
 class ColorChip extends StatelessWidget {
@@ -16,17 +15,9 @@ class ColorChip extends StatelessWidget {
   final String colorHex;
 
   @override
-  Widget build(BuildContext context) {
-    final borderRadius = RadiusData.of(context)!.radiiScheme.medium;
-    return SuggestionChip(
-      text: text,
-      avatar: Container(
-        decoration: BoxDecoration(
-          color: HexColor.fromHex(colorHex),
-          borderRadius: BorderRadius.all(borderRadius),
-        ),
-      ),
-      onPressed: onPressed,
-    );
-  }
+  Widget build(BuildContext context) => SuggestionChip(
+        text: text,
+        avatar: GradientCircle(hexCodes: [colorHex]),
+        onPressed: onPressed,
+      );
 }

--- a/lib/sources/presentation/widgets/chips/gradient_chip.dart
+++ b/lib/sources/presentation/widgets/chips/gradient_chip.dart
@@ -1,6 +1,5 @@
-import 'package:colored/sources/app/styling/radii/radius_data.dart';
-import 'package:colored/sources/common/extensions/hex_color.dart';
 import 'package:colored/sources/presentation/widgets/chips/suggestion_chip.dart';
+import 'package:colored/sources/presentation/widgets/containers/gradient_circle.dart';
 import 'package:flutter/material.dart';
 
 class GradientChip extends StatelessWidget {
@@ -16,22 +15,9 @@ class GradientChip extends StatelessWidget {
   final List<String> hexCodes;
 
   @override
-  Widget build(BuildContext context) {
-    final gradientColors = hexCodes.map(HexColor.fromHex).toList();
-    final borderRadius = RadiusData.of(context)!.radiiScheme.medium;
-    return SuggestionChip(
-      text: text,
-      avatar: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: gradientColors,
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-          borderRadius: BorderRadius.all(borderRadius),
-        ),
-      ),
-      onPressed: onPressed,
-    );
-  }
+  Widget build(BuildContext context) => SuggestionChip(
+        text: text,
+        avatar: GradientCircle(hexCodes: hexCodes),
+        onPressed: onPressed,
+      );
 }

--- a/lib/sources/presentation/widgets/containers/gradient_circle.dart
+++ b/lib/sources/presentation/widgets/containers/gradient_circle.dart
@@ -1,0 +1,35 @@
+import 'package:colored/sources/common/extensions/hex_color.dart';
+import 'package:flutter/material.dart';
+
+class GradientCircle extends StatelessWidget {
+  const GradientCircle({required this.hexCodes, Key? key}) : super(key: key);
+
+  final List<String> hexCodes;
+
+  @override
+  Widget build(BuildContext context) {
+    final gradientColors = _buildColors(hexCodes);
+    return LayoutBuilder(
+      builder: (_, constraints) => Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: gradientColors,
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(constraints.maxHeight / 2),
+        ),
+      ),
+    );
+  }
+
+  List<Color> _buildColors(List<String> hexCodes) {
+    final gradientColors = hexCodes.map(HexColor.fromHex).toList();
+    if (gradientColors.length == 1) {
+      final firstColor = gradientColors.first;
+      return [firstColor, firstColor];
+    } else {
+      return gradientColors;
+    }
+  }
+}

--- a/lib/sources/presentation/widgets/lists/autocomplete_options_list.dart
+++ b/lib/sources/presentation/widgets/lists/autocomplete_options_list.dart
@@ -1,0 +1,67 @@
+import 'package:colored/sources/app/styling/elevation/elevation_data.dart';
+import 'package:colored/sources/app/styling/padding/padding_data.dart';
+import 'package:colored/sources/app/styling/radii/radius_data.dart';
+import 'package:colored/sources/domain/data_models/palette.dart';
+import 'package:colored/sources/presentation/widgets/containers/gradient_circle.dart';
+import 'package:flutter/material.dart';
+
+const _kOptionLeadingSize = 24.0;
+
+class AutocompleteOptionsList extends StatelessWidget {
+  const AutocompleteOptionsList({
+    required this.options,
+    required this.onSelected,
+    required this.availableWidth,
+    this.maxOptionsLenght = 4,
+    Key? key,
+  }) : super(key: key);
+
+  final void Function(Palette) onSelected;
+  final Iterable<Palette> options;
+  final double availableWidth;
+  final int maxOptionsLenght;
+
+  @override
+  Widget build(BuildContext context) {
+    final elevation = ElevationData.of(context)!.elevationScheme.medium;
+    final radii = RadiusData.of(context)!.radiiScheme;
+    final paddingScheme = PaddingData.of(context)!.paddingScheme;
+    final padding = paddingScheme.medium;
+    final textTheme = Theme.of(context).textTheme;
+    final optionsLenght = options.length.clamp(0, maxOptionsLenght);
+    return Padding(
+      padding: EdgeInsets.only(top: paddingScheme.small.top),
+      child: Align(
+        alignment: Alignment.topLeft,
+        child: Material(
+          elevation: elevation,
+          borderRadius: BorderRadius.all(radii.medium),
+          child: SizedBox(
+            height: 56.0 * optionsLenght + padding.top + padding.bottom,
+            width: availableWidth,
+            child: ListView.builder(
+              padding: padding,
+              itemCount: options.length,
+              itemBuilder: (context, index) {
+                final option = options.elementAt(index);
+                return ListTile(
+                  leading: SizedBox(
+                    height: _kOptionLeadingSize,
+                    width: _kOptionLeadingSize,
+                    child: GradientCircle(hexCodes: option.hexCodes),
+                  ),
+                  horizontalTitleGap: 0,
+                  title: Text(option.name, style: textTheme.bodyText1),
+                  onTap: () => onSelected(option),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.all(radii.small),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/sources/presentation/widgets/text_fields/auto_focusing_search_field.dart
+++ b/lib/sources/presentation/widgets/text_fields/auto_focusing_search_field.dart
@@ -8,6 +8,8 @@ class AutoFocusingSearchField extends StatefulWidget {
     this.onSubmitted,
     this.onChanged,
     this.hintText,
+    this.focusNode,
+    this.controller,
     Key? key,
   }) : super(key: key);
 
@@ -16,6 +18,8 @@ class AutoFocusingSearchField extends StatefulWidget {
   final void Function()? onClearPressed;
   final void Function(String)? onSubmitted;
   final void Function(String)? onChanged;
+  final FocusNode? focusNode;
+  final TextEditingController? controller;
 
   @override
   _AutoFocusingSearchFieldState createState() =>
@@ -28,15 +32,13 @@ class _AutoFocusingSearchFieldState extends State<AutoFocusingSearchField> {
 
   @override
   void initState() {
-    _controller = TextEditingController();
-    _focusNode = FocusNode();
-    _setSearchStateValue(widget.searchText);
+    _controller = widget.controller ?? TextEditingController();
+    _focusNode = widget.focusNode ?? FocusNode();
     super.initState();
   }
 
   @override
   void didUpdateWidget(covariant AutoFocusingSearchField oldWidget) {
-    _setSearchStateValue(widget.searchText);
     super.didUpdateWidget(oldWidget);
   }
 
@@ -54,22 +56,6 @@ class _AutoFocusingSearchFieldState extends State<AutoFocusingSearchField> {
         onClearPressed: widget.onClearPressed,
         onChanged: widget.onChanged,
         onSubmitted: widget.onSubmitted,
-      );
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    _focusNode.dispose();
-    super.dispose();
-  }
-
-  void _setSearchStateValue(String search) =>
-      _controller.value = TextEditingValue(
-        text: search,
-        selection: TextSelection(
-          baseOffset: search.length,
-          extentOffset: search.length,
-        ),
       );
 
   void _shouldRequestFocus(String search) {

--- a/lib/sources/presentation/widgets/text_fields/autocomplete_search_field.dart
+++ b/lib/sources/presentation/widgets/text_fields/autocomplete_search_field.dart
@@ -1,0 +1,74 @@
+import 'package:colored/sources/domain/data_models/nameable.dart';
+import 'package:colored/sources/domain/data_models/palette.dart';
+import 'package:colored/sources/presentation/widgets/lists/autocomplete_options_list.dart';
+import 'package:colored/sources/presentation/widgets/text_fields/auto_focusing_search_field.dart';
+import 'package:flutter/material.dart';
+
+class AutocompleteSearchField extends StatelessWidget {
+  const AutocompleteSearchField({
+    required this.searchText,
+    required this.autocompleteOptions,
+    this.onClearPressed,
+    this.onSubmitted,
+    this.onChanged,
+    this.hintText,
+    Key? key,
+  }) : super(key: key);
+
+  final String searchText;
+  final Iterable<Palette> autocompleteOptions;
+  final String? hintText;
+  final void Function()? onClearPressed;
+  final void Function(String)? onSubmitted;
+  final void Function(String)? onChanged;
+
+  @override
+  Widget build(BuildContext context) => LayoutBuilder(
+        builder: (_, constraints) => Autocomplete<Palette>(
+          optionsBuilder: _buildOptions,
+          onSelected: _onOptionSelected,
+          displayStringForOption: (nameable) => nameable.name,
+          fieldViewBuilder: (
+            context,
+            controller,
+            focusNode,
+            onFieldSubmitted,
+          ) =>
+              AutoFocusingSearchField(
+            controller: controller,
+            focusNode: focusNode,
+            searchText: searchText,
+            onClearPressed: onClearPressed,
+            onChanged: onChanged,
+            hintText: hintText,
+            onSubmitted: onSubmitted,
+          ),
+          optionsViewBuilder: (_, onSelected, options) =>
+              AutocompleteOptionsList(
+            options: options,
+            onSelected: onSelected,
+            availableWidth: constraints.maxWidth,
+          ),
+        ),
+      );
+
+  Iterable<Palette> _buildOptions(TextEditingValue textEditingValue) {
+    if (textEditingValue.text.isEmpty) {
+      return [];
+    }
+    final filteredOptions = autocompleteOptions.where((option) {
+      final name = option.name.toLowerCase();
+      final textFieldValue = textEditingValue.text.toLowerCase();
+      return name.contains(textFieldValue);
+    });
+    return filteredOptions;
+  }
+
+  void _onOptionSelected(Nameable nameable) {
+    final _onSubmitted = onSubmitted;
+    if (_onSubmitted == null) {
+      return;
+    }
+    _onSubmitted(nameable.name);
+  }
+}

--- a/test/unit/sources/data/api/services/suggestions/color_suggestions_search_api_service_test.dart
+++ b/test/unit/sources/data/api/services/suggestions/color_suggestions_search_api_service_test.dart
@@ -1,0 +1,164 @@
+import 'dart:convert';
+
+import 'package:colored/sources/data/api/models/index/api_index.dart';
+import 'package:colored/sources/data/api/services/base/request/uri_page_request_builder.dart';
+import 'package:colored/sources/data/api/services/base/response/api_response_parser.dart';
+import 'package:colored/sources/data/api/services/suggestions/color_suggestions_api_service.dart';
+import 'package:colored/sources/data/api/services/suggestions/color_suggestions_search_api_service.dart';
+import 'package:colored/sources/data/pagination/list_page.dart';
+import 'package:colored/sources/data/pagination/page_info.dart';
+import 'package:colored/sources/domain/data_models/named_color.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../network_client/test_helpers/http_client_stubs.dart';
+import '../../test_helpers/test_api_index_response.dart';
+
+const testPageInfo = PageInfo(startIndex: 1, size: 3, pageIndex: 1);
+
+const testColorSuggestionsApiResponse = {
+  "apiVersion": "0.3.0",
+  "method": "GET",
+  "data": {
+    "kind": "color_suggestion",
+    "currentItemCount": 3,
+    "itemsPerPage": 3,
+    "startIndex": 1,
+    "totalItems": 3,
+    "pageIndex": 1,
+    "totalPages": 1,
+    "selfLink": "https://test.com/suggestions/colors/search/names?name=black",
+    "items": [
+      {
+        "color": {
+          "name": "Test Color",
+          "hex": "#000000",
+          "selfLink": "https://test.com/colors/000000"
+        },
+        "selfLink": "https://test.com/suggestions/colors/000000",
+        "colorSearchLink": "https://test.com/colors/search/names?name=Test"
+      },
+      {
+        "color": {
+          "name": "Marsh",
+          "hex": "#5c5337",
+          "selfLink": "https://test.com/colors/5c5337"
+        },
+        "selfLink": "https://test.com/suggestions/colors/5c5337",
+        "colorSearchLink": "https://test.com/colors/search/names?name=Marsh"
+      },
+      {
+        "color": {
+          "name": "Happy",
+          "hex": "#f8d664",
+          "selfLink": "https://test.com/colors/f8d664"
+        },
+        "selfLink": "https://test.com/suggestions/colors/f8d664",
+        "colorSearchLink": "https://test.com/colors/search/names?name=Happy"
+      }
+    ]
+  }
+};
+
+void main() {
+  late ColorSuggestionsSearchApiService service;
+
+  group("Given a $ColorSuggestionsSearchApiService with a null apiIndex", () {
+    setUp(() {
+      service = const ColorSuggestionsSearchApiService(
+        client: HttpClientSuccessfulStub(responseBody: ""),
+        pageRequestBuilder: UriPageRequestBuilder(),
+        apiIndex: null,
+        parser: ApiResponseParser(),
+      );
+    });
+
+    group("when baseUri is called", () {
+      test("then null is retrieved", () {
+        expect(service.baseUri, isNull);
+      });
+    });
+
+    group("when fetchContainingSearch is called", () {
+      test("then null is retrieved", () async {
+        final uri = await service.fetchContainingSearch(
+          "",
+          pageInfo: testPageInfo,
+        );
+        expect(uri, isNull);
+      });
+    });
+  });
+
+  group("Given a $ColorSuggestionsApiService with a valid apiIndex", () {
+    setUp(() {
+      final apiIndex = ApiIndex.fromJsonEntries(testIndex);
+      final responseBody = jsonEncode(testColorSuggestionsApiResponse);
+      service = ColorSuggestionsSearchApiService(
+        client: HttpClientSuccessfulStub(responseBody: responseBody),
+        pageRequestBuilder: const UriPageRequestBuilder(),
+        apiIndex: apiIndex,
+        parser: const ApiResponseParser(),
+      );
+    });
+
+    group("when baseUri is called", () {
+      test("then the request uri is properly built", () {
+        expect(
+          service.baseUri.toString(),
+          contains("https://test.com/suggestions/colors/search/names"),
+        );
+      });
+    });
+
+    group("when parseItemFromJson is called", () {
+      test("then the named color is correctly parsed", () {
+        const testNamedColorJson = {
+          "color": {"name": "Test", "hex": "#000000"},
+        };
+        final namedColor = service.parseItemFromJson(testNamedColorJson);
+        expect(
+          namedColor,
+          const NamedColor(name: "Test", hex: "#000000"),
+        );
+      });
+    });
+
+    group("when fetchContainingSearch is called", () {
+      test("then the list page with the named color is retrieved", () async {
+        final listPage = await service.fetchContainingSearch(
+          "test",
+          pageInfo: testPageInfo,
+        );
+        if (listPage == null) {
+          fail("Expected non-null $ListPage");
+        }
+        expect(listPage.pageInfo, testPageInfo);
+        expect(
+          listPage.items.first,
+          const NamedColor(name: "Test Color", hex: "#000000"),
+        );
+      });
+    });
+  });
+
+  group("Given a $ColorSuggestionsSearchApiService with a failing client", () {
+    setUp(() {
+      service = const ColorSuggestionsSearchApiService(
+        client: HttpClientFailingStub(),
+        pageRequestBuilder: UriPageRequestBuilder(),
+        apiIndex: null,
+        parser: ApiResponseParser(),
+      );
+    });
+
+    group("when fetchContainingSearch is called", () {
+      test("then null is retrieved", () async {
+        final uri = await service.fetchContainingSearch(
+          "test",
+          pageInfo: testPageInfo,
+        );
+        expect(uri, isNull);
+      });
+    });
+  });
+}

--- a/test/unit/sources/data/api/services/suggestions/palette_suggestions_search_api_service_test.dart
+++ b/test/unit/sources/data/api/services/suggestions/palette_suggestions_search_api_service_test.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+
+import 'package:colored/sources/data/api/models/index/api_index.dart';
+import 'package:colored/sources/data/api/services/base/request/uri_page_request_builder.dart';
+import 'package:colored/sources/data/api/services/base/response/api_response_parser.dart';
+import 'package:colored/sources/data/api/services/suggestions/palette_suggestions_search_api_service.dart';
+import 'package:colored/sources/data/pagination/list_page.dart';
+import 'package:colored/sources/data/pagination/page_info.dart';
+import 'package:colored/sources/domain/data_models/palette.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../network_client/test_helpers/http_client_stubs.dart';
+import '../../test_helpers/test_api_index_response.dart';
+
+const testPageInfo = PageInfo(startIndex: 1, size: 1, pageIndex: 1);
+
+const testPaletteSuggestionsApiResponse = {
+  "apiVersion": "0.3.0",
+  "method": "GET",
+  "data": {
+    "kind": "palette_suggestion",
+    "currentItemCount": 1,
+    "itemsPerPage": 1,
+    "startIndex": 1,
+    "totalItems": 1,
+    "pageIndex": 1,
+    "totalPages": 1,
+    "selfLink": "https://test.com/suggestions/palettes/search/names?name=bla",
+    "items": [
+      {
+        "palette": {
+          "id": "619396e040c7f0261f5f400f",
+          "name": "Black",
+          "hexes": [
+            {
+              "hex": "#4aec55",
+              "colorLink":
+                  "https://test.com/colors/search/hexes/closest?hex=4aec55"
+            },
+            {
+              "hex": "#000000",
+              "colorLink":
+                  "https://test.com/colors/search/hexes/closest?hex=000000"
+            }
+          ],
+          "selfLink": "https://test.com/palettes/619396e040c7f0261f5f400f",
+          "colorsSearchLink":
+              "https://test.com/colors/search/hexes/closest?hex=4aec55&hex=000000"
+        },
+        "selfLink":
+            "https://test.com/suggestions/palettes/619396e040c7f0261f5f400f",
+        "paletteSearchLink": "https://test.com/palettes/search/names?name=Black"
+      }
+    ]
+  }
+};
+
+void main() {
+  late PaletteSuggestionsSearchApiService service;
+
+  group("Given a $PaletteSuggestionsSearchApiService with a null apiIndex", () {
+    setUp(() {
+      service = const PaletteSuggestionsSearchApiService(
+        client: HttpClientSuccessfulStub(responseBody: ""),
+        pageRequestBuilder: UriPageRequestBuilder(),
+        apiIndex: null,
+        parser: ApiResponseParser(),
+      );
+    });
+
+    group("when baseUri is called", () {
+      test("then null is retrieved", () {
+        expect(service.baseUri, isNull);
+      });
+    });
+
+    group("when fetchContainingSearch is called", () {
+      test("then null is retrieved", () async {
+        final uri = await service.fetchContainingSearch(
+          "",
+          pageInfo: testPageInfo,
+        );
+        expect(uri, isNull);
+      });
+    });
+  });
+
+  group("Given a $PaletteSuggestionsSearchApiService with valid apiIndex", () {
+    setUp(() {
+      final apiIndex = ApiIndex.fromJsonEntries(testIndex);
+      final responseBody = jsonEncode(testPaletteSuggestionsApiResponse);
+      service = PaletteSuggestionsSearchApiService(
+        client: HttpClientSuccessfulStub(responseBody: responseBody),
+        pageRequestBuilder: const UriPageRequestBuilder(),
+        apiIndex: apiIndex,
+        parser: const ApiResponseParser(),
+      );
+    });
+
+    group("when baseUri is called", () {
+      test("then the request uri is properly built", () {
+        expect(
+          service.baseUri.toString(),
+          contains("https://test.com/suggestions/palettes/search/names"),
+        );
+      });
+    });
+
+    group("when parseItemFromJson is called", () {
+      test("then the palette is correctly parsed", () {
+        const testPaletteJson = {
+          "palette": {
+            "name": "Test",
+            "hexes": [
+              {"hex": "#000000"},
+              {"hex": "#FFFFFF"},
+            ]
+          },
+        };
+        final palette = service.parseItemFromJson(testPaletteJson);
+        expect(palette,
+            const Palette(name: "Test", hexCodes: ["#000000", "#FFFFFF"]));
+      });
+    });
+
+    group("when fetchContainingSearch is called", () {
+      test("then the list page with the palette is retrieved", () async {
+        final listPage = await service.fetchContainingSearch(
+          "bla",
+          pageInfo: testPageInfo,
+        );
+        if (listPage == null) {
+          fail("Expected non-null $ListPage");
+        }
+        expect(listPage.pageInfo, testPageInfo);
+        expect(listPage.items.first,
+            const Palette(name: "Black", hexCodes: ["#4AEC55", "#000000"]));
+      });
+    });
+  });
+
+  group("Given a $PaletteSuggestionsSearchApiService with failing client", () {
+    setUp(() {
+      service = const PaletteSuggestionsSearchApiService(
+        client: HttpClientFailingStub(),
+        pageRequestBuilder: UriPageRequestBuilder(),
+        apiIndex: null,
+        parser: ApiResponseParser(),
+      );
+    });
+
+    group("when fetchContainingSearch is called", () {
+      test("then null is retrieved", () async {
+        final uri = await service.fetchContainingSearch(
+          "test",
+          pageInfo: testPageInfo,
+        );
+        expect(uri, isNull);
+      });
+    });
+  });
+}

--- a/test/unit/sources/data/api/services/suggestions/suggestions_search_api_service_test.dart
+++ b/test/unit/sources/data/api/services/suggestions/suggestions_search_api_service_test.dart
@@ -1,0 +1,87 @@
+import 'package:colored/sources/data/api/services/suggestions/suggestions_search_api_service.dart';
+import 'package:colored/sources/data/pagination/list_page.dart';
+import 'package:colored/sources/data/pagination/page_info.dart';
+import 'package:colored/sources/data/services/names/paginated_names_service.dart';
+import 'package:colored/sources/domain/data_models/named_color.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const testPageInfo = PageInfo(startIndex: 1, size: 3, pageIndex: 1);
+
+class PaginatedNamesServiceStub implements PaginatedNamesService<NamedColor> {
+  const PaginatedNamesServiceStub();
+
+  static const stubbedNamedColors = <NamedColor>[
+    NamedColor(name: "Black", hex: "#000000"),
+    NamedColor(name: "White", hex: "#FFFFFF"),
+  ];
+
+  @override
+  Future<ListPage<NamedColor>?> fetchContainingSearch(
+    String searchString, {
+    required PageInfo pageInfo,
+  }) async =>
+      ListPage.singlePageFromItems(stubbedNamedColors);
+}
+
+void main() {
+  late SuggestionsSearchApiService service;
+  late PaginatedNamesServiceStub stubbedService;
+
+  group("Given a $SuggestionsSearchApiService with a stubbed service", () {
+    setUp(() {
+      stubbedService = const PaginatedNamesServiceStub();
+      service = SuggestionsSearchApiService(
+        namesService: stubbedService,
+      );
+    });
+
+    group("when fetchContainingSearch is called", () {
+      group("with a short searchString", () {
+        test("then a null $ListPage is retrieved", () async {
+          final listPage = await service.fetchContainingSearch(
+            "t",
+            pageInfo: testPageInfo,
+          );
+          expect(listPage, isNull);
+        });
+
+        test("then the last $ListPage is retrieved", () async {
+          final firstPage = await service.fetchContainingSearch(
+            "testing",
+            pageInfo: testPageInfo,
+          );
+          final listPage = await service.fetchContainingSearch(
+            "t",
+            pageInfo: testPageInfo,
+          );
+          expect(listPage, firstPage);
+        });
+      });
+
+      group("with a long searchString", () {
+        test("then a non-null $ListPage is retrieved", () async {
+          final listPage = await service.fetchContainingSearch(
+            "testing",
+            pageInfo: testPageInfo,
+          );
+          if (listPage == null) {
+            fail("Expected a non-null $ListPage.");
+          }
+          expect(listPage.items, PaginatedNamesServiceStub.stubbedNamedColors);
+        });
+
+        test("then the last $ListPage is retrieved", () async {
+          final firstPage = await service.fetchContainingSearch(
+            "testing",
+            pageInfo: testPageInfo,
+          );
+          final listPage = await service.fetchContainingSearch(
+            "testing",
+            pageInfo: testPageInfo,
+          );
+          expect(listPage, firstPage);
+        });
+      });
+    });
+  });
+}

--- a/test/unit/sources/data/services/naming/mock_naming_service_test.dart
+++ b/test/unit/sources/data/services/naming/mock_naming_service_test.dart
@@ -6,9 +6,9 @@ import 'package:colored/sources/domain/data_models/named_color.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   late PaginatedNamesService<NamedColor> namingService;
+
+  setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
 
   setUp(() {
     namingService = const MockNamingService();

--- a/test/unit/sources/domain/data_models/nameable_test.dart
+++ b/test/unit/sources/domain/data_models/nameable_test.dart
@@ -1,0 +1,30 @@
+import 'package:colored/sources/domain/data_models/nameable.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group("Given a $Nameable", () {
+    group("when hashCode is called", () {
+      test("then the hashCode is the same as the hascode from the name", () {
+        const name = "Test";
+        const nameable = Nameable(name);
+        expect(nameable.hashCode, name.hashCode);
+      });
+    });
+  });
+
+  group("Given two $Nameable", () {
+    group("when checking for equality", () {
+      test("two $Nameable are equal if their names are equal", () {
+        const firstNameable = Nameable("First");
+        const secondNameable = Nameable("First");
+        expect(firstNameable == secondNameable, isTrue);
+      });
+
+      test("two $Nameable are not equal if their names are not equal", () {
+        const firstNameable = Nameable("First");
+        const secondNameable = Nameable("Second");
+        expect(firstNameable == secondNameable, isFalse);
+      });
+    });
+  });
+}

--- a/test/unit/sources/domain/data_models/palette_test.dart
+++ b/test/unit/sources/domain/data_models/palette_test.dart
@@ -55,6 +55,15 @@ void main() {
         expect(actual.hexCodes, ["#FFFFFF", "#000000"]);
       });
     });
+
+    group("when fromNamedColor is called", () {
+      test("a Palette from the color is instantiated", () {
+        const testNamedColor = NamedColor(name: "Test", hex: "#000000");
+        final actual = Palette.fromNamedColor(testNamedColor);
+        expect(actual.name, "Test");
+        expect(actual.hexCodes, ["#000000"]);
+      });
+    });
   });
 
   group("Given two valid palettes", () {

--- a/test/unit/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_view_model_test.dart
+++ b/test/unit/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_view_model_test.dart
@@ -1,0 +1,371 @@
+import 'dart:async';
+
+import 'package:colored/sources/data/pagination/list_page.dart';
+import 'package:colored/sources/data/pagination/list_paginator.dart';
+import 'package:colored/sources/data/pagination/page_info.dart';
+import 'package:colored/sources/data/services/names/names_service.dart';
+import 'package:colored/sources/data/services/names/paginated_color_names_service.dart';
+import 'package:colored/sources/data/services/names/paginated_names_service.dart';
+import 'package:colored/sources/domain/data_models/named_color.dart';
+import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
+import 'package:colored/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_view_model.dart';
+import 'package:colored/sources/domain/view_models/colors/names_list/names_list_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+class MockNamesService extends Mock implements NamesService<String> {}
+
+class NamesServiceStub implements NamesService<String> {
+  static const Map<String, String> namesMap = {
+    "testHex": "testName",
+    "000000": "000000",
+    "000001": "000001",
+    "000002": "000002",
+  };
+
+  @override
+  Future<Map<String, String>> fetchContainingSearch(
+          String searchString) async =>
+      namesMap;
+}
+
+class NamesServiceEmptyStub implements NamesService<String> {
+  @override
+  Future<Map<String, String>> fetchContainingSearch(
+          String searchString) async =>
+      {};
+}
+
+class NamesServiceNullStub implements PaginatedNamesService<NamedColor> {
+  const NamesServiceNullStub();
+
+  @override
+  Future<ListPage<NamedColor>?> fetchContainingSearch(
+    String searchString, {
+    required PageInfo pageInfo,
+  }) async =>
+      null;
+}
+
+const testPageInfo = PageInfo(startIndex: 1, size: 1, pageIndex: 1);
+
+const testCurrentNamedColors = [
+  NamedColor(name: "gray", hex: "#111111"),
+  NamedColor(name: "red", hex: "#FF0000"),
+];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ColorSuggestionsSearchViewModel viewModel;
+  late StreamController<NamesListState> stateController;
+  late NamesService<String> namesService;
+
+  setUp(() {
+    stateController = StreamController<NamesListState>();
+    namesService = MockNamesService();
+    viewModel = ColorSuggestionsSearchViewModel(
+      stateController: stateController,
+      namesService: PaginatedColorNamesService(
+        namesService: namesService,
+        paginator: const ListPaginator(),
+      ),
+    );
+  });
+
+  tearDown(() {
+    stateController.close();
+  });
+
+  group("Given a $ColorSuggestionsSearchViewModel", () {
+    group("when initialState is called", () {
+      test("then a Starting state is received", () {
+        final initialState = viewModel.initialState;
+        expect(initialState, isA<Starting>());
+      });
+    });
+
+    group("when clearSearch is called", () {
+      test("then a Starting state is received", () {
+        stateController.stream.listen(
+          (event) => expect(event, isA<Starting>()),
+        );
+        viewModel.clearSearch();
+      });
+    });
+
+    group("when dispose is called", () {
+      test("then stateController is closed", () {
+        expect(stateController.isClosed, false);
+        viewModel.dispose();
+        expect(stateController.isClosed, true);
+      });
+    });
+
+    group("when stateStream is called", () {
+      test("the stream of the provided state controller is retrieved", () {
+        expect(viewModel.stateStream, stateController.stream);
+      });
+    });
+  });
+
+  group("Given a $ColorSuggestionsSearchViewModel with stubs", () {
+    setUp(() {
+      stateController = StreamController<NamesListState>();
+      namesService = NamesServiceStub();
+      viewModel = ColorSuggestionsSearchViewModel(
+        stateController: stateController,
+        namesService: PaginatedColorNamesService(
+          namesService: namesService,
+          paginator: const ListPaginator(),
+        ),
+      );
+    });
+
+    tearDown(() {
+      stateController.close();
+    });
+
+    group("when searchNextPage is called", () {
+      test("then a Pending state is not added", () async {
+        await viewModel.searchNextPage(
+          "se",
+          currentItems: testCurrentNamedColors,
+          currentPageInfo: testPageInfo,
+        );
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then a Found state is added after the first Pending state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<Found>()),
+            );
+        viewModel.searchNextPage(
+          "red",
+          currentItems: testCurrentNamedColors,
+          currentPageInfo: testPageInfo,
+        );
+      });
+
+      test("then the search from the Pending state is retrieved", () {
+        const expected = "se";
+        stateController.stream.listen(
+          (event) => expect(event.search, expected),
+        );
+        viewModel.searchNextPage(
+          expected,
+          currentItems: testCurrentNamedColors,
+          currentPageInfo: testPageInfo,
+        );
+      });
+
+      test("then the search from the Found state is retrieved", () {
+        const expected = "search";
+        stateController.stream.skip(1).listen(
+              (event) => expect(event.search, expected),
+            );
+        viewModel.searchNextPage(
+          expected,
+          currentItems: testCurrentNamedColors,
+          currentPageInfo: testPageInfo,
+        );
+      });
+
+      group("namedColors are retrieved", () {
+        test("containing the first namedColor from the current colors", () {
+          stateController.stream.skip(1).listen((event) {
+            final found = event as Found;
+            final expected = NamedColor(
+              name: testCurrentNamedColors.first.name,
+              hex: testCurrentNamedColors.first.hex,
+            );
+            final actual = found.namedColors.first;
+            expect(actual, expected);
+          });
+          viewModel.searchNextPage(
+            "red",
+            currentItems: testCurrentNamedColors,
+            currentPageInfo: testPageInfo,
+          );
+        });
+
+        test("containing the first namedColor from the retrieved colors", () {
+          stateController.stream.skip(1).listen((event) {
+            final found = event as Found;
+            const namesMap = NamesServiceStub.namesMap;
+            final expected = NamedColor(
+              name: namesMap.values.toList()[1],
+              hex: "#${namesMap.keys.toList()[1].toUpperCase()}",
+            );
+            final actual = found.namedColors[testCurrentNamedColors.length];
+            expect(actual, expected);
+          });
+          viewModel.searchNextPage(
+            "red",
+            currentItems: testCurrentNamedColors,
+            currentPageInfo: testPageInfo,
+          );
+        });
+      });
+    });
+
+    group("when startSearch is called", () {
+      test("then a Pending state is not added", () async {
+        await viewModel.startSearch("se");
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then Found state is added after the Starting state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<Found>()),
+            );
+        viewModel.startSearch("red");
+      });
+
+      test("then the search from the Starting state is retrieved", () {
+        const expected = "se";
+        stateController.stream.listen(
+          (event) => expect(event.search, expected),
+        );
+        viewModel.startSearch(expected);
+      });
+
+      test("then the search from the Found state is retrieved", () {
+        const expected = "search";
+        stateController.stream.skip(1).listen(
+              (event) => expect(event.search, expected),
+            );
+        viewModel.startSearch(expected);
+      });
+
+      test("then namedColors are retrieved", () {
+        stateController.stream.skip(1).listen((event) {
+          final found = event as Found;
+          final expected = NamedColor(
+            name: NamesServiceStub.namesMap.values.first,
+            hex: "#${NamesServiceStub.namesMap.keys.first.toUpperCase()}",
+          );
+          final actual = found.namedColors.first;
+          expect(actual, expected);
+        });
+        viewModel.startSearch("red");
+      });
+    });
+  });
+
+  group("Given a $ColorSuggestionsSearchViewModel with empty NamesService", () {
+    setUp(() {
+      stateController = StreamController<NamesListState>();
+      namesService = NamesServiceEmptyStub();
+      viewModel = ColorSuggestionsSearchViewModel(
+        stateController: stateController,
+        namesService: PaginatedColorNamesService(
+          namesService: namesService,
+          paginator: const ListPaginator(),
+        ),
+      );
+    });
+
+    tearDown(() {
+      stateController.close();
+    });
+
+    group("when startSearch is called", () {
+      test("then a Pending state is added", () async {
+        await viewModel.startSearch("se");
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then NoneFound is retrieved after the Pending state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<NoneFound>()),
+            );
+        viewModel.startSearch("red");
+      });
+    });
+
+    group("when searchNextPage is called", () {
+      test("then Pending is not added", () async {
+        await viewModel.searchNextPage(
+          "se",
+          currentItems: testCurrentNamedColors,
+          currentPageInfo: testPageInfo,
+        );
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then Found is retrieved after the Pending is added", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<Found>()),
+            );
+        viewModel.searchNextPage(
+          "red",
+          currentItems: testCurrentNamedColors,
+          currentPageInfo: testPageInfo,
+        );
+      });
+
+      test("then namedColors found are the currentItems", () {
+        stateController.stream.skip(1).listen((event) {
+          final found = event as Found;
+          expect(found.namedColors, testCurrentNamedColors);
+        });
+        viewModel.searchNextPage(
+          "red",
+          currentItems: testCurrentNamedColors,
+          currentPageInfo: testPageInfo,
+        );
+      });
+    });
+  });
+
+  group("Given a $ColorSuggestionsSearchViewModel with an stubs", () {
+    setUp(() {
+      stateController = StreamController<NamesListState>();
+      viewModel = ColorSuggestionsSearchViewModel(
+        stateController: stateController,
+        namesService: const NamesServiceNullStub(),
+      );
+    });
+
+    tearDown(() {
+      stateController.close();
+    });
+
+    group("when startSearch is called", () {
+      test("then a Pending state is not added", () async {
+        await viewModel.startSearch("se");
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then NoneFound is retrieved after the Pending state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<NoneFound>()),
+            );
+        viewModel.startSearch("red");
+      });
+    });
+
+    group("when searchNextPage is called", () {
+      test("then a Pending state is not added", () async {
+        await viewModel.searchNextPage(
+          "red",
+          currentPageInfo: testPageInfo,
+          currentItems: testCurrentNamedColors,
+        );
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then NoneFound is retrieved after the Pending state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<NoneFound>()),
+            );
+        viewModel.searchNextPage(
+          "red",
+          currentPageInfo: testPageInfo,
+          currentItems: testCurrentNamedColors,
+        );
+      });
+    });
+  });
+}

--- a/test/unit/sources/domain/view_models/palettes/palette_suggestions/search/palette_suggestions_search_view_model_test.dart
+++ b/test/unit/sources/domain/view_models/palettes/palette_suggestions/search/palette_suggestions_search_view_model_test.dart
@@ -1,0 +1,377 @@
+import 'dart:async';
+
+import 'package:colored/sources/data/pagination/list_page.dart';
+import 'package:colored/sources/data/pagination/list_paginator.dart';
+import 'package:colored/sources/data/pagination/page_info.dart';
+import 'package:colored/sources/data/services/names/names_service.dart';
+import 'package:colored/sources/data/services/names/paginated_names_service.dart';
+import 'package:colored/sources/data/services/names/paginated_palette_names_service.dart';
+import 'package:colored/sources/domain/data_models/palette.dart';
+import 'package:colored/sources/domain/view_models/base/names/names_state.dart';
+import 'package:colored/sources/domain/view_models/colors/color_suggestions/search/color_suggestions_search_view_model.dart';
+import 'package:colored/sources/domain/view_models/palettes/palette_suggestions/search/palette_suggestions_search_view_model.dart';
+import 'package:colored/sources/domain/view_models/palettes/palettes_list/palettes_list_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+class MockNamesService extends Mock implements NamesService<List<String>> {}
+
+class NamesServiceStub implements NamesService<List<String>> {
+  static const Map<String, List<String>> namesMap = {
+    "testHex": ["testName", "testName2"],
+    "000000": ["000000", "000000"],
+    "000001": ["000001", "000001"],
+    "000002": ["000002", "000002"],
+  };
+
+  @override
+  Future<Map<String, List<String>>> fetchContainingSearch(
+          String searchString) async =>
+      namesMap;
+}
+
+class NamesServiceEmptyStub implements NamesService<List<String>> {
+  @override
+  Future<Map<String, List<String>>> fetchContainingSearch(
+          String searchString) async =>
+      {};
+}
+
+class NamesServiceNullStub implements PaginatedNamesService<Palette> {
+  const NamesServiceNullStub();
+
+  @override
+  Future<ListPage<Palette>?> fetchContainingSearch(
+    String searchString, {
+    required PageInfo pageInfo,
+  }) async =>
+      null;
+}
+
+const testPageInfo = PageInfo(startIndex: 1, size: 1, pageIndex: 1);
+
+const testCurrentPalettes = [
+  Palette(name: "gray", hexCodes: ["#111111", "#111111"]),
+  Palette(name: "red", hexCodes: ["#FF0000", "#FF0000"]),
+];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late PaletteSuggestionsSearchViewModel viewModel;
+  late StreamController<NamesListState> stateController;
+  late NamesService<List<String>> namesService;
+
+  setUp(() {
+    stateController = StreamController<NamesListState>();
+    namesService = MockNamesService();
+    viewModel = PaletteSuggestionsSearchViewModel(
+      stateController: stateController,
+      namesService: PaginatedPaletteNamesService(
+        namesService: namesService,
+        paginator: const ListPaginator(),
+      ),
+    );
+  });
+
+  tearDown(() {
+    stateController.close();
+  });
+
+  group("Given a $PaletteSuggestionsSearchViewModel", () {
+    group("when initialState is called", () {
+      test("then a Starting state is received", () {
+        final initialState = viewModel.initialState;
+        expect(initialState, isA<Starting>());
+      });
+    });
+
+    group("when clearSearch is called", () {
+      test("then a Starting state is received", () {
+        stateController.stream.listen(
+          (event) => expect(event, isA<Starting>()),
+        );
+        viewModel.clearSearch();
+      });
+    });
+
+    group("when dispose is called", () {
+      test("then stateController is closed", () {
+        expect(stateController.isClosed, false);
+        viewModel.dispose();
+        expect(stateController.isClosed, true);
+      });
+    });
+
+    group("when stateStream is called", () {
+      test("the stream of the provided state controller is retrieved", () {
+        expect(viewModel.stateStream, stateController.stream);
+      });
+    });
+  });
+
+  group("Given a $PaletteSuggestionsSearchViewModel with stubs", () {
+    setUp(() {
+      stateController = StreamController<NamesListState>();
+      namesService = NamesServiceStub();
+      viewModel = PaletteSuggestionsSearchViewModel(
+        stateController: stateController,
+        namesService: PaginatedPaletteNamesService(
+          namesService: namesService,
+          paginator: const ListPaginator(),
+        ),
+      );
+    });
+
+    tearDown(() {
+      stateController.close();
+    });
+
+    group("when searchNextPage is called", () {
+      test("then a Pending state is not added", () async {
+        await viewModel.searchNextPage(
+          "se",
+          currentItems: testCurrentPalettes,
+          currentPageInfo: testPageInfo,
+        );
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then a Found state is added after the first Pending state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<Found>()),
+            );
+        viewModel.searchNextPage(
+          "red",
+          currentItems: testCurrentPalettes,
+          currentPageInfo: testPageInfo,
+        );
+      });
+
+      test("then the search from the Pending state is retrieved", () {
+        const expected = "se";
+        stateController.stream.listen(
+          (event) => expect(event.search, expected),
+        );
+        viewModel.searchNextPage(
+          expected,
+          currentItems: testCurrentPalettes,
+          currentPageInfo: testPageInfo,
+        );
+      });
+
+      test("then the search from the Found state is retrieved", () {
+        const expected = "search";
+        stateController.stream.skip(1).listen(
+              (event) => expect(event.search, expected),
+            );
+        viewModel.searchNextPage(
+          expected,
+          currentItems: testCurrentPalettes,
+          currentPageInfo: testPageInfo,
+        );
+      });
+
+      group("namedColors are retrieved", () {
+        test("containing the first namedColor from the current colors", () {
+          stateController.stream.skip(1).listen((event) {
+            final found = event as Found;
+            final expected = Palette(
+              name: testCurrentPalettes.first.name,
+              hexCodes: testCurrentPalettes.first.hexCodes,
+            );
+            final actual = found.palettes.first;
+            expect(actual, expected);
+          });
+          viewModel.searchNextPage(
+            "red",
+            currentItems: testCurrentPalettes,
+            currentPageInfo: testPageInfo,
+          );
+        });
+
+        test("containing the first namedColor from the retrieved colors", () {
+          stateController.stream.skip(1).listen((event) {
+            final found = event as Found;
+            const namesMap = NamesServiceStub.namesMap;
+            final paletteName = namesMap.keys.toList()[1];
+            final expected = Palette(
+              name: paletteName,
+              hexCodes: namesMap[paletteName]!
+                  .map((e) => "#${e.toUpperCase()}")
+                  .toList(),
+            );
+            final actual = found.palettes[testCurrentPalettes.length];
+            expect(actual, expected);
+          });
+          viewModel.searchNextPage(
+            "red",
+            currentItems: testCurrentPalettes,
+            currentPageInfo: testPageInfo,
+          );
+        });
+      });
+    });
+
+    group("when startSearch is called", () {
+      test("then a Pending state is not added", () async {
+        await viewModel.startSearch("se");
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then Found state is added after the Starting state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<Found>()),
+            );
+        viewModel.startSearch("red");
+      });
+
+      test("then the search from the Starting state is retrieved", () {
+        const expected = "se";
+        stateController.stream.listen(
+          (event) => expect(event.search, expected),
+        );
+        viewModel.startSearch(expected);
+      });
+
+      test("then the search from the Found state is retrieved", () {
+        const expected = "search";
+        stateController.stream.skip(1).listen(
+              (event) => expect(event.search, expected),
+            );
+        viewModel.startSearch(expected);
+      });
+
+      test("then namedColors are retrieved", () {
+        stateController.stream.skip(1).listen((event) {
+          final found = event as Found;
+          final expected = Palette(
+            name: NamesServiceStub.namesMap.keys.first,
+            hexCodes: NamesServiceStub.namesMap.values.first
+                .map((e) => "#${e.toUpperCase()}")
+                .toList(),
+          );
+          final actual = found.palettes.first;
+          expect(actual, expected);
+        });
+        viewModel.startSearch("red");
+      });
+    });
+  });
+
+  group("Given a $ColorSuggestionsSearchViewModel with empty NamesService", () {
+    setUp(() {
+      stateController = StreamController<NamesListState>();
+      namesService = NamesServiceEmptyStub();
+      viewModel = PaletteSuggestionsSearchViewModel(
+        stateController: stateController,
+        namesService: PaginatedPaletteNamesService(
+          namesService: namesService,
+          paginator: const ListPaginator(),
+        ),
+      );
+    });
+
+    tearDown(() {
+      stateController.close();
+    });
+
+    group("when startSearch is called", () {
+      test("then a Pending state is added", () async {
+        await viewModel.startSearch("se");
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then NoneFound is retrieved after the Pending state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<NoneFound>()),
+            );
+        viewModel.startSearch("red");
+      });
+    });
+
+    group("when searchNextPage is called", () {
+      test("then Pending is not added", () async {
+        await viewModel.searchNextPage(
+          "se",
+          currentItems: testCurrentPalettes,
+          currentPageInfo: testPageInfo,
+        );
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then Found is retrieved after the Pending is added", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<Found>()),
+            );
+        viewModel.searchNextPage(
+          "red",
+          currentItems: testCurrentPalettes,
+          currentPageInfo: testPageInfo,
+        );
+      });
+
+      test("then namedColors found are the currentItems", () {
+        stateController.stream.skip(1).listen((event) {
+          final found = event as Found;
+          expect(found.palettes, testCurrentPalettes);
+        });
+        viewModel.searchNextPage(
+          "red",
+          currentItems: testCurrentPalettes,
+          currentPageInfo: testPageInfo,
+        );
+      });
+    });
+  });
+
+  group("Given a $ColorSuggestionsSearchViewModel with an stubs", () {
+    setUp(() {
+      stateController = StreamController<NamesListState>();
+      viewModel = PaletteSuggestionsSearchViewModel(
+        stateController: stateController,
+        namesService: const NamesServiceNullStub(),
+      );
+    });
+
+    tearDown(() {
+      stateController.close();
+    });
+
+    group("when startSearch is called", () {
+      test("then a Pending state is not added", () async {
+        await viewModel.startSearch("se");
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then NoneFound is retrieved after the Pending state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<NoneFound>()),
+            );
+        viewModel.startSearch("red");
+      });
+    });
+
+    group("when searchNextPage is called", () {
+      test("then a Pending state is not added", () async {
+        await viewModel.searchNextPage(
+          "red",
+          currentPageInfo: testPageInfo,
+          currentItems: testCurrentPalettes,
+        );
+        expect(await viewModel.stateStream.first, isNot(isA<Pending>()));
+      });
+
+      test("then NoneFound is retrieved after the Pending state", () {
+        stateController.stream.skip(1).listen(
+              (event) => expect(event, isA<NoneFound>()),
+            );
+        viewModel.searchNextPage(
+          "red",
+          currentPageInfo: testPageInfo,
+          currentItems: testCurrentPalettes,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
* feat(autocomplete): adds autocomplete search field

* feat(autocomplete): adds leading colors to autocomplete options list

* feat(autocomplete): adds color suggestions search api service

* feat(autocomplete): adds color suggestions search injector

* feat(autocomplete): adds color suggestions search data and notifier

* feat(autocomplete): starts color suggestions search integration

* feat(autocomplete): integrates suggestions search views

* feat(autocomplete): polishes suggestions search feature

* feat(autocomplete): adds tests for suggestions search service

* feat(autocomplete): refactors color suggestions search view model

* feat(autocomplete): adds palette suggestions search api service

* feat(autocomplete): adds palette suggestions search view model